### PR TITLE
Changed npm cmd for prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Developer-friendly:
   - [autoprefixer](https://github.com/postcss/autoprefixer): `npm install -g autoprefixer`
   - [postcss-cli](https://github.com/postcss/postcss-cli):`npm install -g postcss-cli`
 
-Note: If you are using [Hugo as a snap app](https://snapcraft.io/hugo), the above two Node.js packages have to be installed locally inside `exampleSite`.
+Note: If you are using [Hugo as a snap app](https://snapcraft.io/hugo), the above two Node.js packages have to be [installed locally inside `exampleSite`](https://gohugo.io/hugo-pipes/postcss/).
 
 ```
 cd exampleSite/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Developer-friendly:
   - [autoprefixer](https://github.com/postcss/autoprefixer): `npm install -g autoprefixer`
   - [postcss-cli](https://github.com/postcss/postcss-cli):`npm install -g postcss-cli`
 
+Note: If you are using [Hugo as a snap app](https://snapcraft.io/hugo), the above two Node.js packages have to be installed locally inside `exampleSite`.
+
+```
+cd exampleSite/
+npm install autoprefixer
+npm install postcss-cli
+```
+
 ## Get the theme
 Run from the root of your Hugo site:
 ```sh

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Developer-friendly:
 ## Requirements
 - Extended version of [Hugo](https://gohugo.io/getting-started/installing/) (latest version recommended)
 - To make changes to the theme CSS:
-  - [autoprefixer](https://github.com/postcss/autoprefixer): `npm install -g autoprefixer`
-  - [postcss-cli](https://github.com/postcss/postcss-cli):`npm install -g postcss-cli`
+  - [autoprefixer](https://github.com/postcss/autoprefixer): `npm install autoprefixer`
+  - [postcss-cli](https://github.com/postcss/postcss-cli):`npm install postcss-cli`
 
 ## Get the theme
 Run from the root of your Hugo site:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Developer-friendly:
 ## Requirements
 - Extended version of [Hugo](https://gohugo.io/getting-started/installing/) (latest version recommended)
 - To make changes to the theme CSS:
-  - [autoprefixer](https://github.com/postcss/autoprefixer): `npm install autoprefixer`
-  - [postcss-cli](https://github.com/postcss/postcss-cli):`npm install postcss-cli`
+  - [autoprefixer](https://github.com/postcss/autoprefixer): `npm install -g autoprefixer`
+  - [postcss-cli](https://github.com/postcss/postcss-cli):`npm install -g postcss-cli`
 
 ## Get the theme
 Run from the root of your Hugo site:


### PR DESCRIPTION
Tested on my Xubuntu 18.04 laptop:

If the installation of these node packages are global (with the `-g` option), `hugo server --themesDir=../..` will throw an error, saying that the `autoprefixer` can't be found.  However, if this option is removed, the same `hugo` command will the site locally for preview.