### PR TITLE
More French word for bug

### DIFF
--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,7 +1,7 @@
 [404_title]
     other = "404"
 [404_description]
-    other = "Oups ! Vous avez soit trouvé un bug{{ with .Site.Params.email }} (auquel cas, [dites-le moi](mailto:{{ . }})) {{ end }} ou vous vous imaginez des choses. Cette page n'existe pas !"
+    other = "Oups ! Vous avez soit trouvé un bogue{{ with .Site.Params.email }} (auquel cas, [dites-le moi](mailto:{{ . }})) {{ end }} ou vous vous imaginez des choses. Cette page n'existe pas !"
 [index_projects_allProjects]
     other = "Tous les projets"
 [index_blog_latestPosts]


### PR DESCRIPTION
The current translation is totally fine, but I've found a more French word for "bug".  See [Word Reference's En/Fr entry for "bug"](https://www.wordreference.com/enfr/bug).  The French word "bogue" is marked with "synonyme recommandé", which means "recommended syntax".

![Screenshot_2019-08-10 bug - English-French Dictionary WordReference com](https://user-images.githubusercontent.com/5748535/62818652-5afcc600-bb4a-11e9-85fd-8e7a798885fe.png)
