### PR TITLE
Enable home page content to specify a template to use for rendering.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -62,6 +62,9 @@
         {{ else if eq (os.Stat .File.Dir).Name "blog" }}
             <!-- Let`s show some blog posts -->
             {{ partial "home/blog.html" . }}
+        {{ else if .Params.Template }}
+            <!-- This page specifies a template, use that -->
+            {{ partial .Params.Template . }}
         {{ else }}
 
         <!-- Range through all sections in /home execept contact.md -->


### PR DESCRIPTION
## Background

The context for this PR is that I was looking to split the projects section into two routes. `/projects` and `/photography`. I was able to do 95% of that outside of the theme by creating a new context type and linking/copying the relevant project templates. What I was not able to do was get the `/photography` route to render on the home page in a manner similar to the projects summary.

## Changes

To enable switching out the template for sections of the home page, an optional `template` parameter is checked. If that parameter is specified, the section renders using that partial template, otherwise it falls back to the existing behaviour.

In my example above, to enable a photography section on the home page, I can simply create a `photography.md` file in `content/home/`

```
---
title: "Photography"
template: "home/photography.html"
weight: 10
---

```