### PR TITLE
Show Hugo version number in a meta tag

### DIFF
--- a/layouts/partials/head/metadata.html
+++ b/layouts/partials/head/metadata.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8">
+{{ hugo.Generator }}
 <meta http-equiv="X-UA-Compatible" content="chrome=1">
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
# Description

Use `{{ hugo.Generator }}` to automatically insert a meta tag like

```html
<meta name="generator" content="Hugo 0.56.3">
```

into the head of each page.

# Motivation

To show the actual version of Hugo used for compilation for debugging.

In https://github.com/victoriadrake/hugo-theme-introduction/pull/153#issuecomment-491608951, @hanzei asked for this particular piece of information.  With this PR, one can quickly retrive this without waiting for other's response.

# External links

1. The place where I've learnt this: https://github.com/pacollins/hugo-future-imperfect-slim/blob/d80bfe573cb7f423be4fe861a1dd108aac3eef0e/layouts/partials/head.html#L3
2. Related docs: https://gohugo.io/variables/hugo/