### PR TITLE
Put time format and time zone in params instead of params.home

### DIFF
--- a/assets/js/initMoment.js
+++ b/assets/js/initMoment.js
@@ -1,4 +1,6 @@
 $(document).ready(function() {
-    var time = moment().tz("{{ .Site.Params.home.timeZone }}").format("{{ .Site.Params.home.timeFormat }}");
+    var time = moment()
+        .tz("{{ or .Site.Params.timeZone .Site.Params.home.timeZone }}")
+        .format("{{ or .Site.Params.timeFormat .Site.Params.home.timeFormat }}");
     $("#time").html(time);
 })

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,8 +11,8 @@ DefaultContentLanguage           = "en"                    # Default language fo
     fadeIn                       = true                    # Turn on/off the fade-in effect
     fadeInIndex                  = false                   # Turn on/off the fade-in effect on the index page even if fade-in was otherwise turned off
     dateFormat                   = "Jan 2, 2006"
-    timeZone                 = "America/Los_Angeles"   # Your timezone as in the TZ* column of this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timeFormat               = "h:mm A"                # https://momentjs.com/docs/#/displaying/format/
+    timeZone                     = "America/Los_Angeles"   # Your timezone as in the TZ* column of this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timeFormat                   = "h:mm A"                # https://momentjs.com/docs/#/displaying/format/
     email                        = "youremail@email.com"   # E-mail address for contact section
     # customCSS                    = ["foo.css"]             # Include custom css files placed under assets/
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,6 +11,8 @@ DefaultContentLanguage           = "en"                    # Default language fo
     fadeIn                       = true                    # Turn on/off the fade-in effect
     fadeInIndex                  = false                   # Turn on/off the fade-in effect on the index page even if fade-in was otherwise turned off
     dateFormat                   = "Jan 2, 2006"
+    timeZone                 = "America/Los_Angeles"   # Your timezone as in the TZ* column of this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timeFormat               = "h:mm A"                # https://momentjs.com/docs/#/displaying/format/
     email                        = "youremail@email.com"   # E-mail address for contact section
     # customCSS                    = ["foo.css"]             # Include custom css files placed under assets/
 
@@ -20,10 +22,7 @@ DefaultContentLanguage           = "en"                    # Default language fo
         showLatest               = true                    # Show latest blog post summary
         showAllPosts             = false                   # Set true to list all posts on home page, or set false to link to separate blog list page
         numberOfProjectsToShow   = 3                       # Maximum number of projects to show on home page. Unset or comment out to show all projects
-
         localTime                = true                    # Show your current local time in contact section
-        timeZone                 = "America/Los_Angeles"   # Your timezone as in the TZ* column of this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-        timeFormat               = "h:mm A"                # https://momentjs.com/docs/#/displaying/format/
     [params.projects]
         useTwoColumns            = false                   # Use a layout with two columns instead of three
 


### PR DESCRIPTION
Currently, the `timeZone` and `timeFormat` parameters are in the `params.home` section of the configuration file. This is not consistent with the `dateFormat` that is directly in the `params` section and I don't see why this setting should be just for the home page.

The advantage of having the settings in the `params` section is with multi-lingual sites : you can have "HH:mm" for European version and "h:mm A" for US version of the page. If the setting is in `params.home` the whole `params.home` section has to be duplicated. Indeed, if you have a `language.xx.params.home` section, it does not *override* the `params.home` with the new settings, but it *replaces* the whole section.