### PR TITLE
Some Dark Theme Fixes

### DIFF
--- a/assets/sass/_dark-variables.sass
+++ b/assets/sass/_dark-variables.sass
@@ -1,6 +1,8 @@
-$body-color: #78888b
-$background: #111111
+$body-color: #dfdfdf
+$background: #121212
 $primary: #ed6a5a
 $secondary: #f4f1bb
 $h-color: #75b8c8
+$navbar-item-color: $body-color
+$code-background: #222222
 $link-hover: $secondary


### PR DESCRIPTION
This PR makes a couple changes to the dark theme:

1. Tweaks the color of text and background to be (IMO) more readable; the background is slightly lighter, while the body text is significantly lighter (increasing contrast).
2. ~~Fixes the inline code background being blindingly bright.~~ I think that was due to some other changes on my end, oops. Actually it fixes the code background being indistinguishable from the rest of the page :)
3. Makes the nav bars' text color match the body text like they do on light theme (they're kinda unreadable without this tweak).

I've been using and tweaking this theme for my personal site for a while and it's great, thank you! Most of my changes are based on my personal preference so I won't open PRs from them (feel free to check out my fork and see if there are any you think are worth contributing upstream), but some of them like this one I feel are universal enough to be worth contributing. 