### PR TITLE
Add Naive "Auto" Light/Dark Theme

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -2,6 +2,25 @@
 $fa-font-path: '{{ "/fonts/fontawesome-free/webfonts" }}'
 $nunito-font-path: '{{ "/fonts/NunitoSans" }}'
 
+{{ if eq $themeStyle "auto" }}
+@import "fonts"
+@import "light-variables"
+@import "base-variables"
+@import "bulma-import"
+@import "fontawesome-import"
+@import "base"
+@import "light-style"
+
+@media (prefers-color-scheme: dark)
+    @import "fonts"
+    @import "dark-variables"
+    @import "base-variables"
+    @import "bulma-import"
+    @import "fontawesome-import"
+    @import "base"
+    @import "dark-style"
+
+{{ else }}
 @import "fonts"
 @import "{{ $themeStyle }}-variables"
 @import "base-variables"
@@ -9,3 +28,4 @@ $nunito-font-path: '{{ "/fonts/NunitoSans" }}'
 @import "fontawesome-import"
 @import "base"
 @import "{{ $themeStyle }}-style"
+{{ end }}


### PR DESCRIPTION
This adds an "automatic" light/dark style by basically creating a double stylesheet that sticks the whole "dark" theme CSS in a media query. It's probably not the best way to handle doing this, but it works. :)

The theme works as-is for "light" or "dark" styles, and adds an additional setting: "auto". If the style is "auto", it will import the light stylesheets, then import the "dark" ones in a media query that checks if the user prefers dark themes. This should not have any compatibility impact (browsers that don't support the `prefers-color-scheme` media query should just ignore it). 

One downside of this approach is that it significantly increases the size of the resulting CSS file (doubles it, in fact). The resulting CSS file is about 50kb after minification, which isn't too bad.