### PR TITLE
Fix social icons with new version of FontAwesome

### DIFF
--- a/layouts/partials/home/social.html
+++ b/layouts/partials/home/social.html
@@ -1,7 +1,7 @@
 <div class="social-icons">
     {{ range .Site.Params.social }}
     <a href="{{ .url }}" {{ .html_attributes | safeHTMLAttr }}>
-        <i class="{{ .icon_pack}} fa-{{ .icon}}"></i>
+        <i class="{{ .icon_pack}} fab fa-{{ .icon}}"></i>
     </a>
     {{ end }}
 </div>


### PR DESCRIPTION
FontAwesome changed the way brand icons should be invoked. This commit updates the social section to use the new, updated way.

See https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#changes for more details.