### PR TITLE
allow images of any ratio to be set as thumbnails without stretching them

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -75,8 +75,8 @@ pre
     border: none
 
 .card-thumbnail
-  width: 100%	  width: 100%
-  height: 100%	  height: 100%
+  width: 100%	 
+  height: 100%
   object-fit: cover
 
 .bold-title

--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -74,6 +74,11 @@ pre
 .thumbnail
     border: none
 
+.card-thumbnail
+  width: 100%	  width: 100%
+  height: 100%	  height: 100%
+  object-fit: cover
+
 .bold-title
     font-size: 6rem
     line-height: 1.2

--- a/layouts/partials/home/projects.html
+++ b/layouts/partials/home/projects.html
@@ -24,7 +24,7 @@
                                     {{ with .Resources.ByType "image" }}
                                     {{ range first 1 (sort . "Params.weight") }}
                                     {{ $image := .Resize $width }}
-                                    <img src="{{ $image.Permalink }}" alt ="{{ $image.Name }}">
+                                    <img class="card-thumbnail" src="{{ $image.Permalink }}" alt ="{{ $image.Name }}">
                                     {{ end }}
                                     {{ end }}
                                 </a>


### PR DESCRIPTION
the results can be seen on my website where I have deployed those changes (www.scifiostia.it):
images in the project section have different ratios but are now displayed correctly