### PR TITLE
Use BaseURL for fonts to handle urls that have path components.

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -1,6 +1,6 @@
 {{ $themeStyle := .Site.Params.themeStyle | default "light" }}
-$fa-font-path: '{{ "/fonts/fontawesome-free/webfonts" }}'
-$nunito-font-path: '{{ "/fonts/NunitoSans" }}'
+$fa-font-path: '{{ print $.Site.BaseURL "fonts/fontawesome-free/webfonts" }}'
+$nunito-font-path: '{{ print $.Site.BaseURL "fonts/NunitoSans" }}'
 
 {{ if eq $themeStyle "auto" }}
 @import "fonts"


### PR DESCRIPTION
If you visit https://themes.gohugo.io/theme/hugo-theme-introduction/ for the demo hosted on the hugo site, you can see that the icons are messed up. I was noticing the same issue on my gitlab pages deployment. The issue is that the CSS compiled was being compiled to `url(/fonts/<font file>)` which is a relative path. The relative path begins after the domain. However, some sites host the index of a page on a path e.g. https://themes.gohugo.io**/theme/hugo-theme-introduction/**.
