### PR TITLE
Correct Blog heading color for light and dark theme

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -34,9 +34,7 @@ a
         color: $primary
 
 h1, h2, .title, .subtitle
-    color: $h-color
-    & a
-        color: $h-color
+    color: $h-color    
 
 .title
     font-weight: $title-weight


### PR DESCRIPTION
Setting "a $h-color" was breaking correct color rendering for blog post titles in light theme. It was trying to override the href element color i.e. # 00b8d4 with title color # 222222

Solves #254 

Before:

![Screenshot 2020-11-07 at 13 10 26](https://user-images.githubusercontent.com/16030809/98440724-a78ed280-20fa-11eb-97f4-404099e43c24.png)


After:

![Screenshot 2020-11-07 at 13 09 04](https://user-images.githubusercontent.com/16030809/98440712-8a5a0400-20fa-11eb-97b3-0b287803f7af.png)
