### PR TITLE
removed /

### DIFF
--- a/assets/vendor/fontawesome-free/scss/_variables.scss
+++ b/assets/vendor/fontawesome-free/scss/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-$fa-font-path:                "/fonts/fontawesome-free/webfonts/" !default;
+$fa-font-path:                "/fonts/fontawesome-free/webfonts" !default;
 $fa-font-size-base:           16px !default;
 $fa-css-prefix:               fa !default;
 $fa-version:                  "5.2.0" !default;


### PR DESCRIPTION
Just started using this great theme, after deploying the website live I found out I get /fonts/fontawesome-free/webfonts//fa-* errors. After removing the trailing / in $fa-font-path no more errors.
Maybe it's just my setup or not the right way but this fixes the problem.