### PR TITLE
Only include Plausible if enabled

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
     <head>
         {{ block "head" . }}
         {{ partial "head/metadata.html" . }}
-        {{ partial "head/plausible.html" . }}
+        {{ if .Site.Params.plausible }}{{ partial "head/plausible.html" . }}{{ end }}
         {{ partial "head/openGraph.html" . }}
         {{ partial "head/favicons.html" . }}
         {{ partial "head/css.html" . }}


### PR DESCRIPTION
Plausible's JS is always included on non-home pages, even when disabled. This PR fixes that by mirroring the `{{ if }}` from the home page.