### PR TITLE
Use image on home for projects only when project has an image

### DIFF
--- a/layouts/partials/home/projects.html
+++ b/layouts/partials/home/projects.html
@@ -18,6 +18,7 @@
                 {{ end}}
                 <div class="column {{ $columWidth }}">
                     <div class="card" data-target="#project-{{ $index }}">
+                        {{ if .Resources.ByType "image" }}
                         <div class="card-image">
                             <figure class="image is-3by2">
                                 <a {{ if .Params.external_link }} href="{{ .Params.external_link }}" {{ end }}>
@@ -30,6 +31,7 @@
                                 </a>
                             </figure>
                         </div>
+                        {{ end }}
                         <div class="card-content has-text-centered top-pad">
                             <a {{ if .Params.external_link }} href="{{ .Params.external_link }}" {{ end }}>
                                 {{ .Title | markdownify }}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -15,6 +15,7 @@
                 {{ end}}
                 <div class="column {{ $columWidth }}">
                     <div class="card">
+                        {{ if .Resources.ByType "image" }}
                         <div class="card-image">
                             <figure class="image is-3by2">
                                 <a href="{{ if .Params.external_link }}{{ .Params.external_link }}{{ else }}{{ .Permalink }}{{ end }}">
@@ -27,6 +28,7 @@
                                 </a>
                             </figure>
                         </div>
+                        {{ end }}
                         <div class="card-content has-text-centered top-pad">
                             <a href="{{ if .Params.external_link }}{{ .Params.external_link }}{{ else }}{{ .Permalink }}{{ end }}">
                                 {{ .Title | markdownify }}


### PR DESCRIPTION
When project does not have image then do not include a div placeholder for the image. The title of the project is pushed below, so that creates a blank space above the project title which seems strange when whole role is without image. Simple visualization is when you try this with exampleSite that allows ALL projects.

Change here enables, that when all projects in the same row that do not have an image, are more centered in the square. 