### PR TITLE
Add option to display project_timeframe to the project pages and home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ resources:
           weight: -100
 ```
 
+If project timeline or start of the project is important and should be displayed in the projects summary on home page, as well as in modal description you can add `project_timeline` string to the frontmatter.
+
 ## Blog section
 
 Create an index file for the blog:

--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ resources:
     - src: NameOfYourImage.jpg
       params:
           weight: -100
+project_timeframe: "June-December"
 ```
 
-If project timeline or start of the project is important and should be displayed in the projects summary on home page, as well as in modal description you can add `project_timeline` string to the frontmatter.
+You can add a `project_timeframe` parameter to the frontmatter of your project to optionally display an arbitrary string on the homepage and modal.
 
 ## Blog section
 

--- a/layouts/partials/home/projects.html
+++ b/layouts/partials/home/projects.html
@@ -34,6 +34,9 @@
                             <a {{ if .Params.external_link }} href="{{ .Params.external_link }}" {{ end }}>
                                 {{ .Title | markdownify }}
                             </a>
+                            {{ if .Params.project_timeframe }}
+                            <p class="fa-xs">{{ .Params.project_timeframe }}</p>
+                            {{ end }}
                         </div>
                     </div>
                 </div>
@@ -58,7 +61,9 @@
                 <p class="modal-card-title has-text-centered">{{ . }}</p>
             </header>
             {{ end }}
-
+            {{ if .Params.project_timeframe }}
+            <p class="fa-xs">{{ .Params.project_timeframe }}</p>
+            {{ end }}
             {{ with .Resources.ByType "image" }}
             {{ $moreThenOneImage := gt (len .) 1 }}
             {{ if $moreThenOneImage }}


### PR DESCRIPTION
Project timeline or time frame of the project is sometimes very important aspect of your project, as
it shows that you have been working on it for some time. It also enables you to only put starting date or any other description to the summary. It is to be defined as string, as some might want range, some might want start date, some might want end date. 

Only uses the feature when it is defined.

I added some docs in README, because I noticed that even `exampleSite` does not have all the features added in the frontmatter. Tell me if docs are somewhere else.