### PR TITLE
Add option for giscus comment section

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -35,6 +35,21 @@ DefaultContentLanguage           = "en"                    # Default language fo
         facebook                 = true
         pinterest                = true
 
+    # To enable giscus, the github discussions based comment section,
+    # Follow the steps described to enable giscus and get the values
+    # needed to populate the below information.
+    # https://www.joelnitta.com/posts/2021-11-24_using-giscus/
+    [params.giscus]
+        # repo = "github-user/github-repo" # Entering repo will enable giscus
+        repo-id = "enter-repo-id"
+        category = "Comments"
+        category-id = "enter-category-id"
+        mapping = "pathname"
+        reactions-enabled = "1"
+        emit-metadata = "0"
+        theme = "light"
+        lang = "en"
+
     # Social icons appear in introduction and contact section. Add as many more as you like.
     # Icon pack "fab" includes social network icons, see: https://fontawesome.com/icons?d=gallery&s=brands&m=free
     # Icon pack "fas" includes solid style icons, see: https://fontawesome.com/icons?d=gallery&s=solid&m=free

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -7,15 +7,15 @@
 {{- if .Site.Params.giscus.repo }}
 <div class="container giscus my-4">
     <script src="https://giscus.app/client.js"
-        data-repo="{{ .Site.Params.giscus.repo }}"
-        data-repo-id="{{ .Site.Params.giscus.repo_id }}"
-        data-category="{{ .Site.Params.giscus.category }}"
-        data-category-id="{{ .Site.Params.giscus.category_id }}"
-        data-mapping="{{ .Site.Params.giscus.mapping }}"
-        data-reactions-enabled="{{ .Site.Params.giscus.reactions_enabled | default 0}}"
-        data-emit-metadata="{{ .Site.Params.giscus.emit_metadata | default 0 }}"
-        data-theme="{{ .Site.Params.giscus.theme }}"
-        data-lang="{{ .Site.Params.giscus.lang }}"
+        data-repo={{ .Site.Params.giscus.repo }}
+        data-repo-id={{ .Site.Params.giscus.repo_id }}
+        data-category={{ .Site.Params.giscus.category }}
+        data-category-id={{ .Site.Params.giscus.category_id }}
+        data-mapping={{ .Site.Params.giscus.mapping }}
+        data-reactions-enabled={{ .Site.Params.giscus.reactions_enabled | default 0}}
+        data-emit-metadata={{ .Site.Params.giscus.emit_metadata | default 0 }}
+        data-theme={{ .Site.Params.giscus.theme }}
+        data-lang={{ .Site.Params.giscus.lang }}
         crossorigin="anonymous"
         async>
     </script>

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -3,3 +3,21 @@
         {{ template "_internal/disqus.html" . }}
     </div>
 {{- end }}
+
+{{- if .Site.Params.giscus.repo }}
+<div class="container giscus my-4">
+    <script src="https://giscus.app/client.js"
+        data-repo="{{ .Site.Params.giscus.repo }}"
+        data-repo-id="{{ .Site.Params.giscus.repo_id }}"
+        data-category="{{ .Site.Params.giscus.category }}"
+        data-category-id="{{ .Site.Params.giscus.category_id }}"
+        data-mapping="{{ .Site.Params.giscus.mapping }}"
+        data-reactions-enabled="{{ .Site.Params.giscus.reactions_enabled | default 0}}"
+        data-emit-metadata="{{ .Site.Params.giscus.emit_metadata | default 0 }}"
+        data-theme="{{ .Site.Params.giscus.theme }}"
+        data-lang="{{ .Site.Params.giscus.lang }}"
+        crossorigin="anonymous"
+        async>
+    </script>
+</div>
+{{- end }}


### PR DESCRIPTION
giscus is a comment section based on GItHub discussions.
This should enable users to specify to use it, rather than for instance disqus. 

About giscus:
https://github.com/giscus/giscus