### PR TITLE
Add support for multiple authors per post

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -206,7 +206,7 @@ details[open] summary
 .markdown
     color: $body-color !important
     p
-        margin-bottom: 1em
+        margin: 1em 0
     h1
         font-size: $size-1
         @include mobile

--- a/exampleSite/content/en/blog/multi-author.md
+++ b/exampleSite/content/en/blog/multi-author.md
@@ -1,0 +1,27 @@
+---
+title: "Support for Multiple Authors"
+date: 2022-02-21T16:04:06-05:00
+tags: ["features", "blog"]
+series: ["quickstart"]
+author: ["Hugo Contributors"]
+---
+
+Using Introduction, your site can feature multiple authors. Each post displays a byline -- the name of a post's author -- if the `author` field is set in the post front matter. For example, here's the front matter for this post:
+
+```yaml
+---
+title: "Support for Multiple Authors"
+date: 2022-02-20T02:04:06-05:00
+tags: ["features", "blog"]
+series: ["quickstart"]
+author: ["Hugo Contributors"]
+---
+```
+
+You can list one or more authors. For example, here's a byline with two credits:
+
+```yaml
+author: ["Hugo Contributors", "Victoria Drake"]
+```
+
+Even when there is just one author, ensure you use a list format (`["Name"]`) for the `author` field.

--- a/exampleSite/resources/_gen/assets/sass/sass/style.sass_7642ba43b3212fd7d7ba324df3b88b0c.content
+++ b/exampleSite/resources/_gen/assets/sass/sass/style.sass_7642ba43b3212fd7d7ba324df3b88b0c.content
@@ -9021,7 +9021,7 @@ details[open] summary {
 .markdown {
   color: #4a4a4a !important; }
   .markdown p {
-    margin-bottom: 1em; }
+    margin: 1em 0; }
   .markdown h1 {
     font-size: 3rem; }
     @media screen and (max-width: 768px) {
@@ -12422,7 +12422,7 @@ readers do not read off random characters that represent icons */
   .markdown {
     color: #ffffff !important; }
     .markdown p {
-      margin-bottom: 1em; }
+      margin: 1em 0; }
     .markdown h1 {
       font-size: 3rem; } }
     @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -11,7 +11,13 @@
     </h2>
     {{ if .Params.author }}
     <h4 class="title is-4">
-        By {{ .Params.author | markdownify }}
+        {{ $data := .Params.author }}
+        By&nbsp;{{- range first 1 $data -}}
+            {{ . | markdownify }}
+        {{- end -}}
+        {{- range after 1 $data -}}
+            ,&nbsp;{{ . | markdownify }}
+        {{- end -}}
     </h4>
     {{ end }}
     <div class="post-data">
@@ -55,7 +61,7 @@
     <p>
         {{ $taxonomy_term | title }}:
         {{ range $key, $value := $taxonomy }}
-        <a href="{{ (printf " /%s/" $taxonomy_term) | relLangURL }}{{ . | urlize }}">
+        <a href="{{ (printf "/%s/" $taxonomy_term) | relLangURL }}{{ . | urlize }}">
             {{ $value }}</a>{{ if ne (add $key 1) $len }},{{ end }}
         {{ end }}
     </p>


### PR DESCRIPTION
Extends #322. This change may break existing posts that have this line in their front matter:

```yaml
author: Author's Name
```

Introduction now displays multiple authors in a post, if there are any. To show a single author, use this format:

```yaml
author: ["Author's Name"]
```

For multiple authors:

```yaml
author: ["Author's Name", "Another Author's Name"]
```

If you omit the `author` parameter, no byline will be shown.