### PR TITLE
Include an option to remove the navigation menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ See the [hugo documentation](https://gohugo.io/content-management/multilingual/)
 
 Introduction contains a default menu. If you want to override this, you can do so by defining a `menu.main` in `config.toml`.
 
+Optionally, you can disable this menu by setting `showMenu` to `false` in your `config.toml`.
+
 ## Contact section clock
 
 Introduction can optionally show your current local time in your [contact section](https://hugo-introduction.netlify.app/#contact). This uses vanilla JS and variables you provide. You can set this up by copying the settings in the exampleSite `config.toml` for `localTime`, `timeZone`, and `timeFormat`.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,6 +7,7 @@ DefaultContentLanguage           = "en"                    # Default language fo
 [params]
     themeStyle                   = "auto"                  # Choose "light" or "dark" or "auto"
     favicon                      = "/img/fav.ico"          # Path to favicon file
+    showMenu                     = true                    # Show navigation menu
     showRSSButton                = false                   # Show rss button in navigation
     fadeIn                       = true                    # Turn on/off the fade-in effect
     fadeInIndex                  = false                   # Turn on/off the fade-in effect on the index page even if fade-in was otherwise turned off

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,3 +1,4 @@
+{{ if .Site.Params.showMenu | default true }}
 <!-- Begin Nav bar -->
 <div class="container">
     <hr>
@@ -115,3 +116,4 @@
     <hr>
 </div>
 <!-- End Nav bar -->
+{{ end }}


### PR DESCRIPTION
**The PR includes an option to show/remove the navigation menu if necessary (Resolves #339)**

It adds an `if` statement in the `layouts/partials/nav.html`, without displaying the navbar if it evaluates to `false`.
It also adds some information about the new option in the `README.md` file, and updates the `config.toml` file in the example site.