### PR TITLE
config.toml secure by default to https://

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseURL                          = "http://example.com/"   # Your domain name. Must end with "/"
+baseURL                          = "https://example.com/"   # Your domain name. Must end with "/"; Secure by default if you need you can fall back to http:// only
 theme                            = "introduction"
 DefaultContentLanguage           = "en"                    # Default language for multilingual sites
 # disqusshortname                 = ""                     # https://gohugo.io/content-management/comments


### PR DESCRIPTION
Change the exampleSite config.toml to be secure by default to https://

Signed-off-by: OrlinVasilev <orlin@orlix.org>