### PR TITLE
Missing import for auto dark mode, fixes #337

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -13,6 +13,7 @@
     @import "fonts"
     @import "dark-variables"
     @import "base-variables"
+    @import "bulma-import"
     @import "fontawesome-import"
     @import "base"
     @import "dark-style"


### PR DESCRIPTION
The background rendered properly if dark mode was specified explicitly in the config.toml, but not if the config.toml specified auto mode and then dark mode was chosen by the client.