### PR TITLE
Fix background bleed behind card images

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -194,10 +194,10 @@ details[open] summary
         margin-right: 1rem
 
 .card
+    background-color: transparent
     box-shadow: none
 
 .card-content
-    background-color: $background
     font-size: 1.5rem
 
 .has-content-centered


### PR DESCRIPTION
This fixes issue #354 by setting the background of the entire card to transparent, instead of setting the content (caption) to `$background`.

**Screenshots:**
*Light Theme*
![introduction-corners-new-light](https://user-images.githubusercontent.com/24282108/216793257-7a9a597f-ab9d-4d2f-93f3-fb5dc1831c24.jpg)
*Dark Theme*
![introduction-corners-new-dark](https://user-images.githubusercontent.com/24282108/216793263-234e69fc-60a3-4177-b4f6-780a5146fe6d.jpg)
*Black background, red border*
![introduction-corners-new-red](https://user-images.githubusercontent.com/24282108/216793289-b8524ca0-2ee7-4374-8db9-51aff2d60dfb.jpg)
*Black background, red border, 50px radius*
![introduction-corners-new-red-50](https://user-images.githubusercontent.com/24282108/216793282-bb6b60e6-c432-498b-941f-1a059285d8b6.jpg)