### PR TITLE
Use hugo.IsServer instead of .Site.IsServer

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -1,6 +1,6 @@
 {{ $bundleRaw := resources.Get "sass/style.sass" | resources.ExecuteAsTemplate "css/main.tmp.css" . }}
 
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
 {{ $cssOpts := (dict "targetPath" "css/main.css" "enableSourceMap" true ) }}
 {{ $bundle := $bundleRaw | toCSS $cssOpts }}
 <link rel="stylesheet" href="{{ $bundle.RelPermalink }}" media="screen">


### PR DESCRIPTION
Fix the following error:
```
ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.136.0. Use hugo.IsServer instead.
```